### PR TITLE
Remove .html from the url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     canonical-rails (0.0.1)
-      rails (~> 3.2.2)
+      rails (~> 3.1)
 
 GEM
   remote: http://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.18)
+    mime-types (1.19)
     multi_json (1.2.0)
     polyglot (0.3.3)
     rack (1.4.1)
@@ -97,10 +97,10 @@ GEM
     sqlite3 (1.3.5)
     thor (0.14.6)
     tilt (1.3.3)
-    treetop (1.4.10)
+    treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.32)
+    tzinfo (0.3.35)
 
 PLATFORMS
   ruby

--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -8,13 +8,17 @@ module CanonicalRails
     def trailing_slash_if_needed
       "/" if trailing_slash_needed? and request.path != '/'
     end
+
+    def path_without_html_extension
+      request.path.sub(/\.html$/, '')
+    end
     
     def canonical_host
       CanonicalRails.host || request.host
     end
     
     def canonical_href
-      "#{request.protocol}#{canonical_host}#{request.path}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+      "#{request.protocol}#{canonical_host}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
     end
     
     def canonical_tag

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -1,4 +1,4 @@
-crequire 'spec_helper'
+require 'spec_helper'
 
 describe CanonicalRails::TagHelper do
   
@@ -26,7 +26,7 @@ describe CanonicalRails::TagHelper do
     it 'should return a nil whitelisted query string' do
       helper.whitelisted_query_string.should be_nil
     end
-    
+
     describe 'on a collection action' do
       before(:each) do
         controller.request.path_parameters = {'controller' => 'our_resources', 'action' => 'index'}
@@ -38,6 +38,16 @@ describe CanonicalRails::TagHelper do
       
       it 'should output a canonical tag w/ trailing slash' do
         helper.canonical_href.last.should == '/'
+      end
+
+      context "with the html extension in the url" do
+        before(:each) do
+          controller.request.path += ".html"
+        end
+
+        it "removes it" do
+          helper.canonical_href.should_not include(".html")
+        end
       end
     end
     
@@ -52,6 +62,16 @@ describe CanonicalRails::TagHelper do
       
       it 'should output a canonical tag w/out trailing slash' do
         helper.canonical_href.last.should_not == '/'
+      end
+
+      context "with the html extension in the url" do
+        before(:each) do
+          controller.request.path += ".html"
+        end
+
+        it "removes it" do
+          helper.canonical_href.should_not include(".html")
+        end
       end
     end
   end


### PR DESCRIPTION
The canonical url should be unique independently from the presence of the `.html` extension
