### PR TITLE
Dependent of rails ">= 3.1", "< 5.0" will work with rails 4.*

### DIFF
--- a/canonical-rails.gemspec
+++ b/canonical-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 3.1"
+  s.add_dependency "rails", ">= 3.1", "< 5.0"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Hi. rails-canonical with rails4.0.0.beta1 raise an error:

```
Bundler could not find compatible versions for gem "rails":
  In Gemfile:
    canonical-rails (>= 0) ruby depends on
      rails (~> 3.1) ruby

    rails (4.0.0.beta1)
```
