### PR TITLE
Allow host to be passed to canonical_href or canonical_tag

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -17,12 +17,12 @@ module CanonicalRails
       CanonicalRails.host || request.host
     end
     
-    def canonical_href
-      "#{request.protocol}#{canonical_host}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+    def canonical_href(host=canonical_host)
+      "#{request.protocol}#{host}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
     end
     
-    def canonical_tag
-      tag(:link, :href => canonical_href, :rel => 'canonical')
+    def canonical_tag(host=canonical_host)
+      tag(:link, :href => canonical_href(host), :rel => 'canonical')
     end
     
     def whitelisted_params

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -124,4 +124,24 @@ describe CanonicalRails::TagHelper do
       end
     end
   end
+
+  describe 'when host is specified' do
+    before(:each) do
+      controller.request.path_parameters = {'controller' => 'our_resources', 'action' => 'show'}
+    end
+
+    describe '#canonical_href' do
+      subject{ helper.canonical_href('www.foobar.net') }
+      it 'uses provided host' do
+        should eq('http://www.foobar.net/our_resources')
+      end
+    end
+
+    describe '#canonical_tag' do
+      subject{ helper.canonical_tag('www.foobar.net') }
+      it 'uses provided host' do
+        should include('www.foobar.net')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi Dennis. I enjoyed your talk at spreeconf, sorry I didn't get a chance to say hi afterwards.

This commit allows specifying the host when calling `canonical_href` or `canonical_tag`. This is useful if the canonical host isn't known at startup, or there are multiple canonical hosts (ex. `example.com` -> `www.example.com`, `example.fr` -> `www.example.fr` or other custom domain logic).

I made this to fix a spree issue. The canonical_rails initializer, [specifically this line](https://github.com/spree/spree/blob/master/frontend/config/initializers/canonical_rails.rb#L5), is run at startup and accesses Spree::Config, which in turn accesses the database (see spree/spree#3833). This will allow us to remove that and change the template to.

```
<%= canonical_tag(Spree::Config.site_url) %>
```

We'll also need this ability as we add some (basic) multitenancy support into spree core. In the future this is likely to be something like:

```
<%= canonical_tag(current_store.site_url) %>
```

Thanks
