### PR TITLE
Enhances port handling for https.

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -25,7 +25,8 @@ module CanonicalRails
     end
 
     def canonical_href(host = canonical_host, port = canonical_port)
-      port = port.present? && port.to_i != 80 ? ":#{port}" : ''
+      default_ports = { 'https://' => 443, 'http://' => 80 }
+      port = port.present? && port.to_i != default_ports[canonical_protocol] ? ":#{port}" : ''
       raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}".downcase
     end
 

--- a/lib/canonical-rails.rb
+++ b/lib/canonical-rails.rb
@@ -33,5 +33,4 @@ module CanonicalRails
   def self.sym_whitelisted_parameters
     @@sym_whitelisted_parameters ||= self.whitelisted_parameters.map(&:to_sym)
   end
-
 end

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -124,6 +124,7 @@ describe CanonicalRails::TagHelper, type: :helper do
       before(:each) do
         CanonicalRails.protocol = 'https://'
         controller.request.path_parameters = { controller: :our_resources, action: :show }
+        allow(controller.request).to receive(:port) { 443 }
       end
 
       after(:each) do


### PR DESCRIPTION
First Thanks for this very nice utility gem!

I stumbled over the issue today that the generated canonical tags always included the port number. Our site is served over https and i discovered a simple solution to the problem. 
I apologize for not opening an issue before sending a PR where you had the chance to discuss a solution to the problem before action is taken. Feel free to comment on the changes made if anything does not meet your level of quality. I'll happily correct my PR.