### PR TITLE
Use params instead of request.params

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -35,7 +35,7 @@ module CanonicalRails
     end
 
     def whitelisted_params
-      request.params.select do |key, value|
+      params.select do |key, value|
         value.present? && CanonicalRails.sym_whitelisted_parameters.include?(key.to_sym)
       end
     end

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -151,7 +151,7 @@ describe CanonicalRails::TagHelper, type: :helper do
     describe 'with parameters' do
       before(:each) do
         CanonicalRails.whitelisted_parameters = ['page', 'keywords', 'search']
-        allow_any_instance_of(controller.request.class).to receive(:query_parameters).and_return({ 'i-will' => 'kill-your-seo', page: '5', keywords: '"here be dragons"', search: { super: 'special' } })
+        allow_any_instance_of(controller.class).to receive(:params).and_return({ 'i-will' => 'kill-your-seo', 'page' => '5', 'keywords' => '"here be dragons"', 'search' => { 'super' => 'special' } })
         controller.request.path_parameters = { controller: :our_resources, action: :index }
       end
 


### PR DESCRIPTION
Hello,
I have a problem with a query string: a key has a value with an "invalid byte sequence in UTF-8" and the call to the whitelisted_params method raises an ArgumentError with the message above (actually, the exception is raised by String#blank? in activesupport) .
So I was wondering... why not using the (hopefully) validated/normalized/sanitized params instead of request.params ?
Maybe there is a simple reason I'm missing right now :)
Thank you for your good work!