### PR TITLE
Add OpenGraph URL support with default: false configuration flag

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -31,7 +31,13 @@ module CanonicalRails
     end
 
     def canonical_tag(host = canonical_host, port = canonical_port)
-      tag(:link, href: canonical_href(host, port), rel: :canonical)
+      canonical_url = canonical_href(host, port)
+      capture do
+        if CanonicalRails.opengraph_url
+          concat tag(:meta, property: 'og:url', content: canonical_url)
+        end
+        concat tag(:link, href: canonical_url, rel: :canonical)
+      end
     end
 
     def whitelisted_params

--- a/lib/canonical-rails.rb
+++ b/lib/canonical-rails.rb
@@ -26,6 +26,9 @@ module CanonicalRails
   mattr_accessor :whitelisted_parameters
   @@whitelisted_parameters = []
 
+  mattr_accessor :opengraph_url
+  @@opengraph_url = false
+
   def self.sym_collection_actions
     @@sym_collection_actions ||= self.collection_actions.map(&:to_sym)
   end

--- a/lib/generators/canonical_rails/install/templates/canonical_rails.rb
+++ b/lib/generators/canonical_rails/install/templates/canonical_rails.rb
@@ -1,13 +1,13 @@
-# Do yourself a favor and set these up right when you install the engine. 
+# Do yourself a favor and set these up right when you install the engine.
 
 CanonicalRails.setup do |config|
 
   # Force the protocol. If you do not specify, the protocol will be based on the incoming request's protocol.
 
   config.protocol#= 'https://'
-  
+
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
-  
+
   config.host# = 'www.mywebstore.com'
   config.port# = '3000'
 
@@ -16,12 +16,14 @@ CanonicalRails.setup do |config|
   # otherwise we have to assume semantics of an instance of a resource type, a member view - implying a :show get route
   #
   # Acts as a whitelist for routes to have trailing slashes
-  
+
   config.collection_actions# = [:index]
 
   # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
   # Unless whitelisted, these parameters will be omitted
-  
+
   config.whitelisted_parameters# = []
-  
+
+  # Output a matching OpenGraph URL meta tag (og:url) with the canonical URL, as recommended by Facebook et al
+  config.opengraph_url#= true
 end

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -236,4 +236,19 @@ describe CanonicalRails::TagHelper, type: :helper do
       end
     end
   end
+
+  describe 'when opengraph url tag is turned on' do
+    before(:each) do
+      CanonicalRails.opengraph_url = true
+      controller.request.path_parameters = { controller: :our_resources, action: :show }
+    end
+
+    describe '#canonical_tag' do
+      subject { helper.canonical_tag }
+
+      it 'outputs an og:url meta tag' do
+        is_expected.to include 'property="og:url"'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds the capability to output an [OpenGraph](http://ogp.me/) `og:url` meta tag alongside the `<link rel=canonical>` tag. 

```ruby
# configuration: 
config.opengraph_url = true

# behavior (paraphrased): 
canonical_tag 
#=> <meta property="og:url" content="..."><link rel="canonical" href="...">
```

Tests and generator have been updated to reflect the change.