### PR TITLE
Rails 5 1/parameters map method deprecation

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -43,7 +43,7 @@ module CanonicalRails
     def whitelisted_params
       params.select do |key, value|
         value.present? && CanonicalRails.sym_whitelisted_parameters.include?(key.to_sym)
-      end
+      end.to_h
     end
 
     def whitelisted_query_string

--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -57,7 +57,15 @@ module CanonicalRails
       # Rack 1.6.0 has it
       # https://github.com/rack/rack/blob/65a7104b6b3e9ecd8f33c63a478ab9a33a103507/test/spec_utils.rb#L251
 
-      "?" + Rack::Utils.build_nested_query(Hash[whitelisted_params.map { |k, v| v.is_a?(Numeric) ? [k, v.to_s] : [k, v] }]) if whitelisted_params.present?
+      wl_params = whitelisted_params
+
+      "?" + Rack::Utils.build_nested_query(convert_numeric_params(wl_params)) if wl_params.present?
+    end
+
+    private
+
+    def convert_numeric_params(params_hash)
+      Hash[params_hash.map { |k, v| v.is_a?(Numeric) ? [k, v.to_s] : [k, v] }]
     end
   end
 end


### PR DESCRIPTION
```
DEPRECATION WARNING: Method map is deprecated and will be removed in
Rails 5.1, as `ActionController::Parameters` no longer inherits from
hash. Using this deprecated behavior exposes potential security
problems. If you continue to use this method you may be creating a
security vulnerability in your app that can be exploited. Instead,
consider using one of these documented methods which are not
deprecated:
http://api.rubyonrails.org/v5.0.2/classes/ActionController/Parameters.ht
ml
```

This deprecation warning was called when using `canonical_tag` method.
After debugging it occurs in `whitelisted_query_string` method while running `map` on `whitelisted_params`.