### PR TITLE
Fix `trailing_slash_needed?` tag helper to handle middleware nasties

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -1,7 +1,7 @@
 module CanonicalRails
   module TagHelper
     def trailing_slash_needed?
-      CanonicalRails.sym_collection_actions.include? request.params['action'].to_sym
+      request.params.key?('action') && CanonicalRails.sym_collection_actions.include?(request.params['action'].to_sym)
     end
 
     def trailing_slash_if_needed

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -258,4 +258,18 @@ describe CanonicalRails::TagHelper, type: :helper do
       end
     end
   end
+
+  describe 'when request action not present' do
+    # Occurs if middleware tries to render a controller action before having gone through the ActionDispatch router
+
+    describe 'on a collection action' do
+      before(:each) do
+        controller.request.path_parameters = {}
+      end
+
+      it 'should assume we dont want a trailing slash' do
+        expect(helper).not_to be_trailing_slash_needed
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
Prevents a null reference exception being raised when middleware has skipped past the ActionDispatch router and rendered an action directly. An example of such a case is devise omniauth `on_failure` handler where the `failure` action is called from within middleware. I'm certain there would be plenty of other cases of this floating around.

#### Where should the reviewer start?
Fix is to just validate that there is an action parameter present before trying to convert it to a symbol. The assumption here is that we wouldn't want to include a slash? Happy to switch to the reverse however?

#### How should this be manually tested?
Some rack middleware with something like this would do it:

```
class MyMiddleware
  def initialize(app)
    @app = app       
  end                

  def call(env)      
    # For what ever reason, our middleware has decided not to call to the next in line.
    # Instead, we're going to call to an action directly
    MyController.action(:some_action).call(env)
  end                
end 
```