### PR TITLE
now can configure trailing slash for controller#action pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ your HTML views:
   <%= canonical_tag -%>
 ```
 
+## Collection actions configuration update (updated 24.07.2017)
+
+You can now specify collection actions for specific controller#action pairs, like this
+
+```ruby
+  config.collection_actions = [[:tags, :show]]
+```
+
 ## Cred
 
 A project by [Downshift Labs](http://downshiftlabs.com), Ruby on Rails,

--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -1,7 +1,11 @@
 module CanonicalRails
   module TagHelper
     def trailing_slash_needed?
-      request.params.key?('action') && CanonicalRails.sym_collection_actions.include?(request.params['action'].to_sym)
+      action = request.params['action']
+      controller = request.params['controller']
+      return false unless action
+      CanonicalRails.sym_collection_actions.include?(action.to_sym) ||
+        !controller.nil? && CanonicalRails.sym_collection_actions.include?([controller.to_sym, action.to_sym])
     end
 
     def trailing_slash_if_needed

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -187,6 +187,22 @@ describe CanonicalRails::TagHelper, type: :helper do
         it 'should output a canonical tag w/ trailing slash' do
           expect(helper.canonical_href).to include '/?'
         end
+
+        context 'when controller/action pair specified' do
+          it 'should output a canonical tag w/ trailing slash if controller#action match' do
+            controller.request.path_parameters = { controller: :some_controller, action: :show}
+            CanonicalRails.class_variable_set(:@@sym_collection_actions, [[:some_controller, :show]])
+
+            expect(helper.canonical_href).to include '/?'
+          end
+
+          it 'should output a canonical tag w/out trailing slash otherwise' do
+            controller.request.path_parameters = { controller: :our_resources, action: :show}
+            CanonicalRails.class_variable_set(:@@sym_collection_actions, [[:some_controller, :show]])
+
+            expect(helper.canonical_href).not_to include '/?'
+          end
+        end
       end
 
       describe 'on a member action' do


### PR DESCRIPTION
Hey!

Sometimes you have a collection assigned to a :show action, for example a single tag page with a collection of items, related to this tag. At least i needed that for our app, so i wrote this.

Now it possible to include a specific controller#action pair to have a trailing slash by providing an array like [:controller, :action]