### PR TITLE
Allow Rails 5.2 in gemspec

### DIFF
--- a/canonical-rails.gemspec
+++ b/canonical-rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'rails', '>= 4.1', '< 5.2'
+  s.add_dependency 'rails', '>= 4.1', '< 5.3'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Since #44 we're testing against rails 5.2.0.rc1 :+1: .

I think it's a pretty safe bet that the 5.2.0 final will be compatible.