### PR TITLE
better handling of trailing slashes for root paths

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -10,6 +10,16 @@ module CanonicalRails
       end
     end
 
+    def canonical_href(host = canonical_host, port = canonical_port)
+      default_ports = { 'https://' => 443, 'http://' => 80 }
+      port = port.present? && port.to_i != default_ports[canonical_protocol] ? ":#{port}" : ''
+      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+    end
+    
+    def canonical_path
+      raw "#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+    end
+
     private
 
     def trailing_slash_needed?
@@ -36,16 +46,6 @@ module CanonicalRails
 
     def canonical_port
       (CanonicalRails.port || request.port).to_i
-    end
-
-    def canonical_href(host = canonical_host, port = canonical_port)
-      default_ports = { 'https://' => 443, 'http://' => 80 }
-      port = port.present? && port.to_i != default_ports[canonical_protocol] ? ":#{port}" : ''
-      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
-    end
-    
-    def canonical_path
-      raw "#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
     end
 
     def whitelisted_params


### PR DESCRIPTION
I have a website https://convopanda.com. I'd like the root canonical url to be `https://convopanda.com`. Currently this is not possible with the gem. It always returns a trailing slash for the root path e.g. `https://convopanda.com/`. This change allows for root path canonical urls without a trailing slash.

I've also made the tag helper private except for the public method `canonical_tag`.