### PR TITLE
Downcasing canonical hrefs to avoid duplicate content flagging

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -27,7 +27,7 @@ module CanonicalRails
     def canonical_href(host = canonical_host, port = canonical_port)
       default_ports = { 'https://' => 443, 'http://' => 80 }
       port = port.present? && port.to_i != default_ports[canonical_protocol] ? ":#{port}" : ''
-      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}".downcase
     end
     
     def canonical_path


### PR DESCRIPTION
Hello.

Usually, a lot of websites suffer from downranking on search engines, caused by using mixed casing on crawled URLs, which then might generate warnings for the search engine crawler (e.g. duplicate content).

Enforcing a casing style on canonicals makes it able to tackle this issue with little to none effort.

If you would like to read more about the issue I'm tackling with this PR, here are two interesting articles:
- https://www.hobo-web.co.uk/duplicate-content-problems/#are-uppercase-and-lowercase-urls-counted-as-two-different-pages-to-google-
- https://www.abramillar.com/2017/01/25/are-urls-case-sensitive/

Thank you.