### PR TITLE
Add trailing slash config option

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -4,6 +4,12 @@ module CanonicalRails
       request.params.key?('action') && CanonicalRails.sym_collection_actions.include?(request.params['action'].to_sym)
     end
 
+    # Leave force_trailing_slash_at_end_of_url as nil to get the original behavior of trailing_slash_if_needed
+    def trailing_slash_config(force_trailing_slash_at_end_of_url = nil)
+      if force_trailing_slash_at_end_of_url return "/"
+      if force_trailing_slash_at_end_of_url.nil? trailing_slash_if_needed
+    end
+
     def trailing_slash_if_needed
       "/" if trailing_slash_needed?
     end
@@ -26,18 +32,18 @@ module CanonicalRails
       (CanonicalRails.port || request.port).to_i
     end
 
-    def canonical_href(host = canonical_host, port = canonical_port)
+    def canonical_href(host = canonical_host, port = canonical_port, force_trailing_slash_at_end_of_url = nil)
       default_ports = { 'https://' => 443, 'http://' => 80 }
       port = port.present? && port.to_i != default_ports[canonical_protocol] ? ":#{port}" : ''
-      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_config(force_trailing_slash_at_end_of_url}#{whitelisted_query_string}"
     end
 
-    def canonical_path
-      raw "#{path_without_html_extension}#{trailing_slash_if_needed}#{whitelisted_query_string}"
+    def canonical_path(force_trailing_slash_at_end_of_url = nil)
+      raw "#{path_without_html_extension}#{trailing_slash_config(force_trailing_slash_at_end_of_url)}#{whitelisted_query_string}"
     end
 
-    def canonical_tag(host = canonical_host, port = canonical_port)
-      canonical_url = canonical_href(host, port)
+    def canonical_tag(host = canonical_host, port = canonical_port, force_trailing_slash_at_end_of_url = nil)
+      canonical_url = canonical_href(host, port, force_trailing_slash_at_end_of_url)
       capture do
         if CanonicalRails.opengraph_url
           concat tag(:meta, property: 'og:url', content: canonical_url)


### PR DESCRIPTION
This PR allows passing a new config option into canonical_tag and canonical_path to force the presence or absence of the trailing_slash. This is the implementation of the change proposed in [PR#43](https://github.com/jumph4x/canonical-rails/pull/43)

By extension, this should also allow us to later fix two long standing issues in Solidus.
https://github.com/solidusio/solidus/issues/1549
https://github.com/solidusio/solidus/issues/1335