### PR TITLE
Explicitly require TagHelper

### DIFF
--- a/lib/canonical-rails/engine.rb
+++ b/lib/canonical-rails/engine.rb
@@ -1,9 +1,11 @@
+require_relative '../../app/helpers/canonical_rails/tag_helper'
+
 module CanonicalRails
   class Engine < ::Rails::Engine
-    
+
     initializer 'canonical_rails.add_helpers' do |app|
       ActionView::Base.send :include, CanonicalRails::TagHelper
     end
-  
+
   end
 end


### PR DESCRIPTION
Since TagHelper is used in an initializer, changes to it will require
reloading the app no matter what. Since Rails 6 started warning about
this, this commit changes it to be manually required to prevent the
deprecation warning.

This resolves https://github.com/jumph4x/canonical-rails/issues/54 for me on Rails 6.0.3.2.