### PR TITLE
feat(port): add force_no_port config parameter

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -32,6 +32,8 @@ module CanonicalRails
     end
 
     def canonical_port
+      return nil if CanonicalRails.force_no_port
+
       (CanonicalRails.port || request.port).to_i
     end
 

--- a/lib/canonical-rails.rb
+++ b/lib/canonical-rails.rb
@@ -17,6 +17,9 @@ module CanonicalRails
   mattr_accessor :port
   @@port = nil
 
+  mattr_accessor :force_no_port
+  @@force_no_port = nil
+
   mattr_accessor :protocol
   @@protocol = nil
 

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -130,6 +130,16 @@ describe CanonicalRails::TagHelper, type: :helper do
           expect(helper.canonical_tag).to include 'http://www.mywebstore.com:3000/our_resources'
         end
       end
+
+      describe 'when force_no_port is set to true in config' do
+        before(:each) do
+          CanonicalRails.force_no_port = true
+        end
+
+        it 'ignores the port in the request' do
+          expect(helper.canonical_tag).to include 'http://www.mywebstore.com/our_resources'
+        end
+      end
     end
 
     describe 'with a specified protocol' do


### PR DESCRIPTION
To ignore the port even if it's present in the request params (otherwise when testing locally you see port 3000 in the canonical url, even with a host set). Related discussions related to this behavior can be found here https://github.com/jumph4x/canonical-rails/pull/24 and here https://github.com/jumph4x/canonical-rails/issues/21. This is a really quick edit so there may be a better solution.