### PR TITLE
Deprecate whitelisted_params config

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -73,10 +73,8 @@ module CanonicalRails
       # https://github.com/rack/rack/blob/9939d40a5e23dcb058751d1029b794aa2f551900/test/spec_utils.rb#L222
       # Rack 1.6.0 has it
       # https://github.com/rack/rack/blob/65a7104b6b3e9ecd8f33c63a478ab9a33a103507/test/spec_utils.rb#L251
-
-      wl_params = allowed_params
-
-      "?" + Rack::Utils.build_nested_query(convert_numeric_params(wl_params)) if wl_params.present?
+      parameters = allowed_params
+      "?" + Rack::Utils.build_nested_query(convert_numeric_params(parameters)) if parameters.present?
     end
 
     private

--- a/lib/canonical-rails.rb
+++ b/lib/canonical-rails.rb
@@ -1,4 +1,5 @@
 require "canonical-rails/engine"
+require "canonical-rails/deprecation"
 
 module CanonicalRails
 
@@ -23,6 +24,10 @@ module CanonicalRails
   mattr_accessor :collection_actions
   @@collection_actions = [:index]
 
+  # @deprecated: use config.allowed_parameters instead
+  mattr_accessor :whitelisted_parameters
+  @@whitelisted_parameters = []
+
   mattr_accessor :allowed_parameters
   @@allowed_parameters = []
 
@@ -34,6 +39,11 @@ module CanonicalRails
   end
 
   def self.sym_allowed_parameters
-    @@sym_allowed_parameters ||= self.allowed_parameters.map(&:to_sym)
+    @@sym_allowed_parameters ||= if self.whitelisted_parameters.empty?
+      self.allowed_parameters.map(&:to_sym)
+    else
+      CanonicalRails::Deprecation.warn('config.whitelisted_parameters is deprecated, please use config.allowed_parameters instead.')
+      self.whitelisted_parameters.map(&:to_sym)
+    end
   end
 end

--- a/lib/canonical-rails/deprecation.rb
+++ b/lib/canonical-rails/deprecation.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'active_support/deprecation'
+
+module CanonicalRails
+  Deprecation = ActiveSupport::Deprecation.new('1.0', 'CanonicalRails')
+end

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -210,6 +210,26 @@ describe CanonicalRails::TagHelper, type: :helper do
         end
       end
     end
+
+    describe 'with the old config.whitelisted_parameters' do
+      before do
+        CanonicalRails.whitelisted_parameters = ['page']
+        allow_any_instance_of(controller.class)
+          .to receive(:params)
+          .and_return(ActionController::Parameters.new('i-will' => 'kill-your-seo', 'page' => '5'))
+        controller.request.path_parameters = { controller: 'our_resources', action: 'index' }
+      end
+
+      after do
+        CanonicalRails.class_variable_set(:@@sym_whitelisted_parameters, nil)
+      end
+
+      it 'emits a deprecation warning and keeps working' do
+        expect(CanonicalRails::Deprecation).to receive(:warn).once
+        expect(helper.allowed_params['page']).to eq '5'
+        expect(helper.allowed_params['i-will']).to be_nil
+      end
+    end
   end
 
   describe 'when host is specified' do


### PR DESCRIPTION
This allows people to switch to the new config without breaking their applications or requiring a new release for libraries using this gem.

See https://github.com/solidusio/solidus/pull/3865, which is still valid but merging this we allow people on older versions of Solidus to upgrade to newer versions of Rails.