### PR TITLE
Adding license information to the .gemspec

### DIFF
--- a/canonical-rails.gemspec
+++ b/canonical-rails.gemspec
@@ -12,7 +12,8 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/jumph4x/canonical-rails"
   s.summary     = "Simple and configurable Rails canonical ref tag helper"
   s.description = "Configurable, but assumes a conservative strategy by default with a goal to solve many search engine index problems: multiple hostnames, inbound links with arbitrary parameters, trailing slashes. "
-
+  s.license     = "MIT"
+  
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency 'rails', '>= 4.1', '< 6.2'


### PR DESCRIPTION
Tools like VersionEye are using this information for license compliance analysis.