### PR TITLE
thin required rails dependencies for canonical-rails

### DIFF
--- a/canonical-rails.gemspec
+++ b/canonical-rails.gemspec
@@ -16,10 +16,13 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'rails', '>= 4.1', '<= 7.1'
+  %w[actionmailer activerecord railties].each do |dep|
+    s.add_dependency dep, '>= 4.1', '<= 7.1'
+  end
+
+  s.add_dependency "sprockets-rails", '~> 3.0'
 
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency "sprockets", '~> 3.0'
   s.add_development_dependency 'rspec-rails', '~> 4.0.1'
   s.add_development_dependency 'pry'
 end

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 4.1.15"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 4.1.15"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 4.2.6"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 4.2.6"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 5.0.0"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 5.0.0"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 5.1.0"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 5.1.0"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 5.2.0.rc1"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 5.2.0"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 6.0.0.beta1"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 6.0.0"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", "~> 6.1.0"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, "~> 6.1.0"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -4,6 +4,9 @@ source "http://rubygems.org"
 
 gem "jquery-rails"
 gem "sqlite3"
-gem "rails", github: "rails/rails", branch: "main"
+
+%w[actionmailer activerecord railties].each do |dep|
+  gem dep, github: "rails", branch: "main"
+end
 
 gemspec path: "../"


### PR DESCRIPTION
So I was looking to remove rails deps that my project does not use. I started with the assumption that we want all rails deps that would be present in a Rails 4.2 installation. We could probably thin this further since I don't believe canonical_rails needs actionmailer but I'm going to wait to see what the CI says.

https://gist.github.com/BenMorganIO/4a68fb8d85434473d01e38162e3bad5c/revisions