### PR TITLE
Remove .htm extensions from url

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -20,7 +20,7 @@ module CanonicalRails
     def path_without_html_extension
       return '' if request.path == '/'
 
-      request.path.sub(/\.html$/, '')
+      request.path.sub(/\.html?$/, '')
     end
 
     def canonical_protocol

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -62,6 +62,16 @@ describe CanonicalRails::TagHelper, type: :helper do
           expect(helper.canonical_href).to_not include '.html'
         end
       end
+
+      context "with the htm extension in the url" do
+        before(:each) do
+          controller.request.path += '.htm'
+        end
+
+        it "removes it" do
+          expect(helper.canonical_href).to_not include '.htm'
+        end
+      end
     end
 
     describe 'on a member action' do


### PR DESCRIPTION
Removing the .htm extension was mentioned back in #1, Rails may not have recognized the .htm extension at that time, but it does now.

Part of me wanted to exclude all extensions because a default Rails app will recognize the path with anything after the dot (e.g. page.php, page.asp, page.blah, etc), but it is probably not a common enough use-case to worry about.