### PR TITLE
Remove all extensions from url

### DIFF
--- a/app/helpers/canonical_rails/tag_helper.rb
+++ b/app/helpers/canonical_rails/tag_helper.rb
@@ -17,10 +17,10 @@ module CanonicalRails
       "/" if trailing_slash_needed?
     end
 
-    def path_without_html_extension
+    def path_without_extension
       return '' if request.path == '/'
 
-      request.path.sub(/\.html?$/, '')
+      request.path.sub(/\.\w{3,4}$/, '')
     end
 
     def canonical_protocol
@@ -38,11 +38,11 @@ module CanonicalRails
     def canonical_href(host = canonical_host, port = canonical_port, force_trailing_slash = nil)
       default_ports = { 'https://' => 443, 'http://' => 80 }
       port = port.present? && port.to_i != default_ports[canonical_protocol] ? ":#{port}" : ''
-      raw "#{canonical_protocol}#{host}#{port}#{path_without_html_extension}#{trailing_slash_config(force_trailing_slash)}#{allowed_query_string}"
+      raw "#{canonical_protocol}#{host}#{port}#{path_without_extension}#{trailing_slash_config(force_trailing_slash)}#{allowed_query_string}"
     end
 
     def canonical_path(force_trailing_slash = nil)
-      raw "#{path_without_html_extension}#{trailing_slash_config(force_trailing_slash)}#{allowed_query_string}"
+      raw "#{path_without_extension}#{trailing_slash_config(force_trailing_slash)}#{allowed_query_string}"
     end
 
     def canonical_tag(host = canonical_host, port = canonical_port, force_trailing_slash = nil)

--- a/spec/helpers/canonical_rails/tag_helper_spec.rb
+++ b/spec/helpers/canonical_rails/tag_helper_spec.rb
@@ -72,6 +72,16 @@ describe CanonicalRails::TagHelper, type: :helper do
           expect(helper.canonical_href).to_not include '.htm'
         end
       end
+
+      context "with the json extension in the url" do
+        before(:each) do
+          controller.request.path += '.json'
+        end
+
+        it "removes it" do
+          expect(helper.canonical_href).to_not include '.json'
+        end
+      end
     end
 
     describe 'on a member action' do


### PR DESCRIPTION
This removes all extensions from the URL, not just htm and html.

Currently htm and html extensions are removed from URLs. The logic is that extensions are basically a URL parameter (under the reserved name `format`), and URL parameters are generally not desirable in canonical URLs. By that logic, all extensions should be removed, not just htm and html.

In fact, if we don't remove all extensions, it allows for "duplicate content" problems where requests for the same page can have different canonical URLs in the response, depending on what extension was on the request.

This change agrees with @joeadcock from #71, when he said he "wanted to exclude all extensions". That seems to be the correct thing.

P.S. Thanks @jumph4x for maintaining this nice gem 🙂 