### PR TITLE
Relax dependency on rails up to 7.2 excluded

### DIFF
--- a/canonical-rails.gemspec
+++ b/canonical-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'actionview', '>= 4.1', '<= 7.1'
+  s.add_dependency 'actionview', '>= 4.1', '<= 7.2'
 
   s.add_development_dependency 'actionpack', '>= 4.1', '<= 7.1'
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Currently when trying to bundle rails 7.1.1 on an app having `canonical-rails` in its Gemfile fails with:

```
Could not find compatible versions

Because canonical-rails < 0.0.3 depends on rails ~> 3.1
  and canonical-rails >= 0.0.3, < 0.1.0 depends on rails >= 3.1, < 5.0,
  canonical-rails < 0.1.0 requires rails >= 3.1, < 5.0.
And because canonical-rails >= 0.1.0, < 0.1.1 depends on rails >= 3.1, < 5.1,
  canonical-rails < 0.1.1 requires rails >= 3.1, < 5.1.
And because canonical-rails >= 0.1.1, < 0.2.0 depends on rails >= 4.1, < 5.1
  and canonical-rails >= 0.2.0, < 0.2.3 depends on rails >= 4.1, < 5.2,
  canonical-rails < 0.2.3 requires rails >= 3.1, < 5.2.
And because canonical-rails >= 0.2.3, < 0.2.5 depends on rails >= 4.1, < 5.3
  and canonical-rails >= 0.2.5, < 0.2.10 depends on rails >= 4.1, < 6.1,
  canonical-rails < 0.2.10 requires rails >= 3.1, < 6.1.
And because canonical-rails >= 0.2.10, < 0.2.13 depends on rails >= 4.1, < 6.2
  and canonical-rails >= 0.2.13, < 0.2.14 depends on rails >= 4.1, <= 7.0,
  canonical-rails < 0.2.14 requires rails >= 3.1, <= 7.0.
So, because canonical-rails >= 0.2.14 depends on rails >= 4.1, <= 7.1
  and Gemfile depends on rails ~> 7.1.1,
  version solving has failed.
```

It seems that declaring a dependency `<= 7.1` excludes versions `7.1.1`, `7.1.2`, etc.