### PR TITLE
Make compatible with Rails 7.2.x

### DIFF
--- a/canonical-rails.gemspec
+++ b/canonical-rails.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'actionview', '>= 4.1', '<= 7.2'
+  s.add_dependency 'actionview', '>= 4.1', '< 7.3'
 
-  s.add_development_dependency 'actionpack', '>= 4.1', '<= 7.1'
+  s.add_development_dependency 'actionpack', '>= 4.1', '< 7.3'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'rspec-rails', '~> 4.0.1'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
After the release of 7.2.1 this gem no longer is compatible. I changed the dependencies here (and changed the inequality sign from `<=` to `<` so it doesn't break on minor version bumps as 7.2.0 technically was compatible but it shouldn't have been)